### PR TITLE
Replace toAscii() by toLatin1()

### DIFF
--- a/src/codegen/rectangle.xml
+++ b/src/codegen/rectangle.xml
@@ -56,7 +56,7 @@
   }
   if (caps[5].length()) {
     m_corners = 0;
-    QByteArray cors = caps[5].toAscii();
+    QByteArray cors = caps[5].toLatin1();
     for (int i = 0; i < cors.count(); ++i) {
       m_corners |= (1 << (cors[i] - '1'));
     }

--- a/src/codegen/symbol.cpp.tmpl
+++ b/src/codegen/symbol.cpp.tmpl
@@ -35,7 +35,7 @@
 {
   QRegExp rx(m_pattern);
   if (!rx.exactMatch(def))
-    throw InvalidSymbolException(def.toAscii());
+    throw InvalidSymbolException(def.toLatin1());
 
   QStringList caps = rx.capturedTexts();
   {{constructor}}

--- a/src/gui/home.cpp
+++ b/src/gui/home.cpp
@@ -160,7 +160,7 @@ void Home::showCustomSymbolPage()
   DIR *dp;
   int i,j;
   struct dirent *dirp;
-  if((dp = opendir(ctx.loader->absPath("symbols").toAscii().data())) == NULL){
+  if((dp = opendir(ctx.loader->absPath("symbols").toLatin1().data())) == NULL){
     qDebug()<<"Error cant find symbol path";
   }
   i=j=0;

--- a/src/parser/charrecord.cpp
+++ b/src/parser/charrecord.cpp
@@ -69,7 +69,7 @@ QPainterPath CharLineRecord::painterPath(qreal width_factor)
 
 CharRecord::CharRecord(FontDataStore* ds, const QStringList& param): ds(ds)
 {
-  tchar = param[1].toAscii()[0];
+  tchar = param[1].toLatin1()[0];
 }
 
 CharRecord::~CharRecord()

--- a/src/parser/odbpp/structuredtextparser.cpp
+++ b/src/parser/odbpp/structuredtextparser.cpp
@@ -54,10 +54,10 @@ StructuredTextDataStore* StructuredTextParser::parse(void)
 
     yyin = _wfopen(buf, (const wchar_t*)"r");
   } else {
-    yyin = fopen(m_fileName.toAscii(), "r");
+    yyin = fopen(m_fileName.toLatin1(), "r");
   }
 #else
-  yyin = fopen(m_fileName.toAscii(), "r");
+  yyin = fopen(m_fileName.toLatin1(), "r");
 #endif
 
   if (yyin == NULL) {

--- a/src/symbol/barcodesymbol.cpp
+++ b/src/symbol/barcodesymbol.cpp
@@ -120,7 +120,7 @@ QPainterPath BarcodeSymbol::painterPath(void)
   qreal wide = narrow * 3;
 
   for (int i = 0; i < bar_pattern.length(); ++i) {
-    switch (bar_pattern[i].toAscii()) {
+    switch (bar_pattern[i].toLatin1()) {
       case 'W':
         path.addRect(offset, 0, wide, -m_h);
         offset += wide;

--- a/src/symbol/butterflysymbol.cpp
+++ b/src/symbol/butterflysymbol.cpp
@@ -34,7 +34,7 @@ ButterflySymbol::ButterflySymbol(const QString& def, const Polarity& polarity,
 {
   QRegExp rx(m_pattern);
   if (!rx.exactMatch(def))
-    throw InvalidSymbolException(def.toAscii());
+    throw InvalidSymbolException(def.toLatin1());
 
   QStringList caps = rx.capturedTexts();
   m_r = caps[1].toDouble() / 1000.0 / 2.0;

--- a/src/symbol/diamondsymbol.cpp
+++ b/src/symbol/diamondsymbol.cpp
@@ -34,7 +34,7 @@ DiamondSymbol::DiamondSymbol(const QString& def, const Polarity& polarity,
 {
   QRegExp rx(m_pattern);
   if (!rx.exactMatch(def))
-    throw InvalidSymbolException(def.toAscii());
+    throw InvalidSymbolException(def.toLatin1());
 
   QStringList caps = rx.capturedTexts();
   m_w = caps[1].toDouble() / 1000.0;

--- a/src/symbol/donutrsymbol.cpp
+++ b/src/symbol/donutrsymbol.cpp
@@ -34,7 +34,7 @@ DonutRSymbol::DonutRSymbol(const QString& def, const Polarity& polarity,
 {
   QRegExp rx(m_pattern);
   if (!rx.exactMatch(def))
-    throw InvalidSymbolException(def.toAscii());
+    throw InvalidSymbolException(def.toLatin1());
 
   QStringList caps = rx.capturedTexts();
   m_od = caps[1].toDouble() / 1000.0;

--- a/src/symbol/donutssymbol.cpp
+++ b/src/symbol/donutssymbol.cpp
@@ -34,7 +34,7 @@ DonutSSymbol::DonutSSymbol(const QString& def, const Polarity& polarity,
 {
   QRegExp rx(m_pattern);
   if (!rx.exactMatch(def))
-    throw InvalidSymbolException(def.toAscii());
+    throw InvalidSymbolException(def.toLatin1());
 
   QStringList caps = rx.capturedTexts();
   m_od = caps[1].toDouble() / 1000.0;

--- a/src/symbol/ellipsesymbol.cpp
+++ b/src/symbol/ellipsesymbol.cpp
@@ -34,7 +34,7 @@ EllipseSymbol::EllipseSymbol(const QString& def, const Polarity& polarity,
 {
   QRegExp rx(m_pattern);
   if (!rx.exactMatch(def))
-    throw InvalidSymbolException(def.toAscii());
+    throw InvalidSymbolException(def.toLatin1());
 
   QStringList caps = rx.capturedTexts();
   m_w = caps[1].toDouble() / 1000.0;

--- a/src/symbol/halfovalsymbol.cpp
+++ b/src/symbol/halfovalsymbol.cpp
@@ -34,7 +34,7 @@ HalfOvalSymbol::HalfOvalSymbol(const QString& def, const Polarity& polarity,
 {
   QRegExp rx(m_pattern);
   if (!rx.exactMatch(def))
-    throw InvalidSymbolException(def.toAscii());
+    throw InvalidSymbolException(def.toLatin1());
 
   QStringList caps = rx.capturedTexts();
   m_w = caps[1].toDouble() / 1000.0;

--- a/src/symbol/holesymbol.cpp
+++ b/src/symbol/holesymbol.cpp
@@ -34,7 +34,7 @@ HoleSymbol::HoleSymbol(const QString& def, const Polarity& polarity,
 {
   QRegExp rx(m_pattern);
   if (!rx.exactMatch(def))
-    throw InvalidSymbolException(def.toAscii());
+    throw InvalidSymbolException(def.toLatin1());
 
   QStringList caps = rx.capturedTexts();
   m_r = caps[1].toDouble() / 1000.0 / 2;

--- a/src/symbol/horizontalhexagonsymbol.cpp
+++ b/src/symbol/horizontalhexagonsymbol.cpp
@@ -34,7 +34,7 @@ HorizontalHexagonSymbol::HorizontalHexagonSymbol(const QString& def, const Polar
 {
   QRegExp rx(m_pattern);
   if (!rx.exactMatch(def))
-    throw InvalidSymbolException(def.toAscii());
+    throw InvalidSymbolException(def.toLatin1());
 
   QStringList caps = rx.capturedTexts();
   m_w = caps[1].toDouble() / 1000.0;

--- a/src/symbol/moiresymbol.cpp
+++ b/src/symbol/moiresymbol.cpp
@@ -35,7 +35,7 @@ MoireSymbol::MoireSymbol(const QString& def, const Polarity& polarity,
 {
   QRegExp rx(m_pattern);
   if (!rx.exactMatch(def))
-    throw InvalidSymbolException(def.toAscii());
+    throw InvalidSymbolException(def.toLatin1());
 
   QStringList caps = rx.capturedTexts();
   m_rw = caps[1].toDouble() / 1000.0;

--- a/src/symbol/nullsymbol.cpp
+++ b/src/symbol/nullsymbol.cpp
@@ -34,7 +34,7 @@ NullSymbol::NullSymbol(const QString& def, const Polarity& polarity,
 {
   QRegExp rx(m_pattern);
   if (!rx.exactMatch(def))
-    throw InvalidSymbolException(def.toAscii());
+    throw InvalidSymbolException(def.toLatin1());
 
   QStringList caps = rx.capturedTexts();
   m_ext = caps[1].toInt();

--- a/src/symbol/octagonsymbol.cpp
+++ b/src/symbol/octagonsymbol.cpp
@@ -34,7 +34,7 @@ OctagonSymbol::OctagonSymbol(const QString& def, const Polarity& polarity,
 {
   QRegExp rx(m_pattern);
   if (!rx.exactMatch(def))
-    throw InvalidSymbolException(def.toAscii());
+    throw InvalidSymbolException(def.toLatin1());
 
   QStringList caps = rx.capturedTexts();
   m_w = caps[1].toDouble() / 1000.0;

--- a/src/symbol/ovalsymbol.cpp
+++ b/src/symbol/ovalsymbol.cpp
@@ -34,7 +34,7 @@ OvalSymbol::OvalSymbol(const QString& def, const Polarity& polarity,
 {
   QRegExp rx(m_pattern);
   if (!rx.exactMatch(def))
-    throw InvalidSymbolException(def.toAscii());
+    throw InvalidSymbolException(def.toLatin1());
 
   QStringList caps = rx.capturedTexts();
   m_w = caps[1].toDouble() / 1000.0;

--- a/src/symbol/rectanglesymbol.cpp
+++ b/src/symbol/rectanglesymbol.cpp
@@ -34,7 +34,7 @@ RectangleSymbol::RectangleSymbol(const QString& def, const Polarity& polarity,
 {
   QRegExp rx(m_pattern);
   if (!rx.exactMatch(def))
-    throw InvalidSymbolException(def.toAscii());
+    throw InvalidSymbolException(def.toLatin1());
 
   QStringList caps = rx.capturedTexts();
   m_w = caps[1].toDouble() / 1000.0;
@@ -51,7 +51,7 @@ RectangleSymbol::RectangleSymbol(const QString& def, const Polarity& polarity,
   }
   if (caps[5].length()) {
     m_corners = 0;
-    QByteArray cors = caps[5].toAscii();
+    QByteArray cors = caps[5].toLatin1();
     for (int i = 0; i < cors.count(); ++i) {
       m_corners |= (1 << (cors[i] - '1'));
     }

--- a/src/symbol/rectangularthermalopencornerssymbol.cpp
+++ b/src/symbol/rectangularthermalopencornerssymbol.cpp
@@ -34,7 +34,7 @@ RectangularThermalOpenCornersSymbol::RectangularThermalOpenCornersSymbol(const Q
 {
   QRegExp rx(m_pattern);
   if (!rx.exactMatch(def))
-    throw InvalidSymbolException(def.toAscii());
+    throw InvalidSymbolException(def.toLatin1());
 
   QStringList caps = rx.capturedTexts();
   m_w = caps[1].toDouble() / 1000.0;

--- a/src/symbol/rectangularthermalsymbol.cpp
+++ b/src/symbol/rectangularthermalsymbol.cpp
@@ -34,7 +34,7 @@ RectangularThermalSymbol::RectangularThermalSymbol(const QString& def, const Pol
 {
   QRegExp rx(m_pattern);
   if (!rx.exactMatch(def))
-    throw InvalidSymbolException(def.toAscii());
+    throw InvalidSymbolException(def.toLatin1());
 
   QStringList caps = rx.capturedTexts();
   m_w = caps[1].toDouble() / 1000.0;

--- a/src/symbol/roundsymbol.cpp
+++ b/src/symbol/roundsymbol.cpp
@@ -34,7 +34,7 @@ RoundSymbol::RoundSymbol(const QString& def, const Polarity& polarity,
 {
   QRegExp rx(m_pattern);
   if (!rx.exactMatch(def))
-    throw InvalidSymbolException(def.toAscii());
+    throw InvalidSymbolException(def.toLatin1());
 
   QStringList caps = rx.capturedTexts();
   m_r = caps[1].toDouble() / 1000.0 / 2.0;

--- a/src/symbol/roundthermalroundsymbol.cpp
+++ b/src/symbol/roundthermalroundsymbol.cpp
@@ -34,7 +34,7 @@ RoundThermalRoundSymbol::RoundThermalRoundSymbol(const QString& def, const Polar
 {
   QRegExp rx(m_pattern);
   if (!rx.exactMatch(def))
-    throw InvalidSymbolException(def.toAscii());
+    throw InvalidSymbolException(def.toLatin1());
 
   QStringList caps = rx.capturedTexts();
   m_od = caps[1].toDouble() / 1000.0;

--- a/src/symbol/roundthermalsquaresymbol.cpp
+++ b/src/symbol/roundthermalsquaresymbol.cpp
@@ -34,7 +34,7 @@ RoundThermalSquareSymbol::RoundThermalSquareSymbol(const QString& def, const Pol
 {
   QRegExp rx(m_pattern);
   if (!rx.exactMatch(def))
-    throw InvalidSymbolException(def.toAscii());
+    throw InvalidSymbolException(def.toLatin1());
 
   QStringList caps = rx.capturedTexts();
   m_od = caps[1].toDouble() / 1000.0;

--- a/src/symbol/squarebutterflysymbol.cpp
+++ b/src/symbol/squarebutterflysymbol.cpp
@@ -34,7 +34,7 @@ SquareButterflySymbol::SquareButterflySymbol(const QString& def, const Polarity&
 {
   QRegExp rx(m_pattern);
   if (!rx.exactMatch(def))
-    throw InvalidSymbolException(def.toAscii());
+    throw InvalidSymbolException(def.toLatin1());
 
   QStringList caps = rx.capturedTexts();
   m_s = caps[1].toDouble() / 1000.0;

--- a/src/symbol/squareroundthermalsymbol.cpp
+++ b/src/symbol/squareroundthermalsymbol.cpp
@@ -35,7 +35,7 @@ SquareRoundThermalSymbol::SquareRoundThermalSymbol(const QString& def, const Pol
 {
   QRegExp rx(m_pattern);
   if (!rx.exactMatch(def))
-    throw InvalidSymbolException(def.toAscii());
+    throw InvalidSymbolException(def.toLatin1());
 
   QStringList caps = rx.capturedTexts();
   m_od = caps[1].toDouble() / 1000.0;

--- a/src/symbol/squaresymbol.cpp
+++ b/src/symbol/squaresymbol.cpp
@@ -34,7 +34,7 @@ SquareSymbol::SquareSymbol(const QString& def, const Polarity& polarity,
 {
   QRegExp rx(m_pattern);
   if (!rx.exactMatch(def))
-    throw InvalidSymbolException(def.toAscii());
+    throw InvalidSymbolException(def.toLatin1());
 
   QStringList caps = rx.capturedTexts();
   m_s = caps[1].toDouble() / 1000.0;

--- a/src/symbol/squarethermalopencornerssymbol.cpp
+++ b/src/symbol/squarethermalopencornerssymbol.cpp
@@ -34,7 +34,7 @@ SquareThermalOpenCornersSymbol::SquareThermalOpenCornersSymbol(const QString& de
 {
   QRegExp rx(m_pattern);
   if (!rx.exactMatch(def))
-    throw InvalidSymbolException(def.toAscii());
+    throw InvalidSymbolException(def.toLatin1());
 
   QStringList caps = rx.capturedTexts();
   m_od = caps[1].toDouble() / 1000.0;

--- a/src/symbol/squarethermalsymbol.cpp
+++ b/src/symbol/squarethermalsymbol.cpp
@@ -34,7 +34,7 @@ SquareThermalSymbol::SquareThermalSymbol(const QString& def, const Polarity& pol
 {
   QRegExp rx(m_pattern);
   if (!rx.exactMatch(def))
-    throw InvalidSymbolException(def.toAscii());
+    throw InvalidSymbolException(def.toLatin1());
 
   QStringList caps = rx.capturedTexts();
   m_od = caps[1].toDouble() / 1000.0;

--- a/src/symbol/textsymbol.cpp
+++ b/src/symbol/textsymbol.cpp
@@ -89,7 +89,7 @@ QPainterPath TextSymbol::painterPath(void)
   QMatrix mat(m_xsize / ds->xsize(), 0, 0, m_ysize / ds->ysize(), 0, 0);
 
   for (int i = 0; i < m_text.length(); ++i) {
-    CharRecord* rec = ds->charRecord(m_text[i].toAscii());
+    CharRecord* rec = ds->charRecord(m_text[i].toLatin1());
     if (rec) {
       QPainterPath p = mat.map(rec->painterPath(m_width_factor));
       path.addPath(p);

--- a/src/symbol/trianglesymbol.cpp
+++ b/src/symbol/trianglesymbol.cpp
@@ -34,7 +34,7 @@ TriangleSymbol::TriangleSymbol(const QString& def, const Polarity& polarity,
 {
   QRegExp rx(m_pattern);
   if (!rx.exactMatch(def))
-    throw InvalidSymbolException(def.toAscii());
+    throw InvalidSymbolException(def.toLatin1());
 
   QStringList caps = rx.capturedTexts();
   m_base = caps[1].toDouble() / 1000.0;

--- a/src/symbol/verticalhexagonsymbol.cpp
+++ b/src/symbol/verticalhexagonsymbol.cpp
@@ -34,7 +34,7 @@ VerticalHexagonSymbol::VerticalHexagonSymbol(const QString& def, const Polarity&
 {
   QRegExp rx(m_pattern);
   if (!rx.exactMatch(def))
-    throw InvalidSymbolException(def.toAscii());
+    throw InvalidSymbolException(def.toLatin1());
 
   QStringList caps = rx.capturedTexts();
   m_w = caps[1].toDouble() / 1000.0;


### PR DESCRIPTION
toAscii() is deprecated in Qt5, and has been removed from recent Qt versions.